### PR TITLE
Add Widefield Imaging (raw and processed) for Blue and Violet channels

### DIFF
--- a/src/pinto_lab_to_nwb/widefield/__init__.py
+++ b/src/pinto_lab_to_nwb/widefield/__init__.py
@@ -1,0 +1,1 @@
+from .widefieldnwbconverter import WideFieldNWBConverter

--- a/src/pinto_lab_to_nwb/widefield/extractors/widefield_imagingextractor.py
+++ b/src/pinto_lab_to_nwb/widefield/extractors/widefield_imagingextractor.py
@@ -1,0 +1,105 @@
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+from neuroconv.utils import FilePathType, FolderPathType
+from pymatreader import read_mat
+from roiextractors import MicroManagerTiffImagingExtractor
+
+# todo move filtering fix to roiextractors
+# Get the logger used by tifffile
+tifffile_logger = logging.getLogger("tifffile")
+
+
+# Define a custom filter class
+class CustomWarningFilter(logging.Filter):
+    def filter(self, record):
+        # Filter out warnings with the specific message
+        return "<tifffile.TiffTag 270 @42054>" not in record.getMessage()
+
+
+# Add the custom filter to the tifffile logger
+custom_filter = CustomWarningFilter()
+tifffile_logger.addFilter(custom_filter)
+
+
+class WidefieldImagingExtractor(MicroManagerTiffImagingExtractor):
+    extractor_name = "WidefieldImaging"
+
+    def __init__(
+        self,
+        folder_path: FolderPathType,
+        strobe_sequence_file_path: FilePathType,
+        channel_name: Optional[str] = "blue",
+    ):
+        """
+        Specialized extractor for reading Widefield imaging experiment data.
+        The extractor reads TIFF files produced via Micro-Manager and uses the strobe sequence to separate the blue and violet channels.
+
+        Parameters
+        ----------
+        folder_path: FolderPathType
+           The folder path that contains the multipage OME-TIF image files (.ome.tif files) and
+           the 'DisplaySettings' JSON file.
+        strobe_sequence_file_path: FilePathType
+            The file path to the strobe sequence file. This file should contain the 'strobe_session_key' key.
+        channel_name: str, optional
+            The name of the channel to load the frames for. The default is 'blue'.
+        """
+
+        super().__init__(folder_path=folder_path)
+        self.channel_name = channel_name
+
+        assert Path(
+            strobe_sequence_file_path
+        ).exists(), f"The strobe sequence file does not exist: {strobe_sequence_file_path}"
+        strobe_sequence_mat = read_mat(strobe_sequence_file_path)
+        assert (
+            "strobe_session_key" in strobe_sequence_mat
+        ), "The strobe sequence file is missing the 'strobe_session_key' key."
+        strobe_sequence_dict = strobe_sequence_mat["strobe_session_key"]
+        assert (
+            "strobe_sequence" in strobe_sequence_dict
+        ), "The strobe sequence file is missing the 'strobe_sequence' key."
+        frame_order = strobe_sequence_dict["strobe_sequence"]
+        strobe_id = dict(blue=1, violet=2)[channel_name]
+
+        self.frame_indices = np.where(frame_order == strobe_id)[0]
+        self._times = strobe_sequence_dict["all_frame_times"][self.frame_indices]
+        assert (
+            len(frame_order) == super().get_num_frames()
+        ), "The number of frames in the strobe sequence does not match the number of frames in the TIFF files."
+        self._num_frames = len(self.frame_indices)
+
+    def get_num_frames(self) -> int:
+        return self._num_frames
+
+    def get_sampling_frequency(self) -> float:
+        return super().get_sampling_frequency() / 2
+
+    def get_channel_names(self) -> List[str]:
+        return [f"OpticalChannel{self.channel_name.capitalize()}"]
+
+    def get_num_channels(self) -> int:
+        return 1
+
+    def get_video(
+        self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0
+    ) -> np.ndarray:
+        start_frame = start_frame or 0
+        end_frame = end_frame or self.get_num_frames()
+
+        # Ensure the end_frame does not exceed the available frames
+        start_frame = min(start_frame, self.get_num_frames() - 1)
+        end_frame = min(end_frame, self.get_num_frames() - 1)
+
+        original_video_start_frame = self.frame_indices[start_frame]
+        original_video_end_frame = self.frame_indices[end_frame]
+        video = super().get_video(
+            start_frame=original_video_start_frame, end_frame=original_video_end_frame, channel=channel
+        )
+
+        filtered_indices = self.frame_indices[start_frame:end_frame] - self.frame_indices[start_frame]
+
+        return video[filtered_indices]

--- a/src/pinto_lab_to_nwb/widefield/extractors/widefield_processed_imagingextractor.py
+++ b/src/pinto_lab_to_nwb/widefield/extractors/widefield_processed_imagingextractor.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+from typing import Tuple, List, Optional
+
+import numpy as np
+from lazy_ops import DatasetView
+from neuroconv.utils import FilePathType
+from pymatreader import read_mat
+from roiextractors import ImagingExtractor
+from roiextractors.extraction_tools import DtypeType
+
+
+class WidefieldProcessedImagingExtractor(ImagingExtractor):
+    extractor_name = "WidefieldProcessedImaging"
+
+    def __init__(
+        self,
+        file_path: FilePathType,
+        info_file_path: FilePathType,
+        strobe_sequence_file_path: FilePathType,
+        channel_name: Optional[str] = "blue",
+    ):
+        """
+        The ImagingExtractor for loading the downsampled imaging data for the Widefield session.
+
+        Parameters
+        ----------
+        file_path: PathType
+           The path that points to downsampled imaging data saved as a Matlab file.
+        info_file_path: PathType
+            The path that points to Matlab file with information about the imaging session (e.g. 'frameRate').
+        strobe_sequence_file_path: PathType
+            The path that points to the strobe sequence file. This file should contain the 'strobe_session_key' key.
+        channel_name: str, optional
+            The name of the channel to load the frames for. The default is 'blue'.
+        """
+        import h5py
+
+        super().__init__(file_path=file_path)
+
+        file = h5py.File(file_path, "r")
+        expected_struct_name = "rawf"
+        assert expected_struct_name in file.keys(), f"'{expected_struct_name}' is not in {file_path}."
+        self._video = DatasetView(file[expected_struct_name])
+
+        assert Path(
+            strobe_sequence_file_path
+        ).exists(), f"The strobe sequence file does not exist: {strobe_sequence_file_path}"
+        strobe_sequence_mat = read_mat(strobe_sequence_file_path)
+        assert (
+            "strobe_session_key" in strobe_sequence_mat
+        ), "The strobe sequence file is missing the 'strobe_session_key' key."
+        strobe_sequence_dict = strobe_sequence_mat["strobe_session_key"]
+        assert (
+            "strobe_sequence" in strobe_sequence_dict
+        ), "The strobe sequence file is missing the 'strobe_sequence' key."
+        frame_order = strobe_sequence_dict["strobe_sequence"]
+        assert channel_name in ["blue", "violet"], f"'channel_name' must be 'blue' or 'violet'."
+        self.channel_name = channel_name
+        strobe_id = dict(blue=1, violet=2)[channel_name]
+
+        self.frame_indices = np.where(frame_order == strobe_id)[0]
+        self._times = strobe_sequence_dict["all_frame_times"][self.frame_indices]
+        assert (
+            len(frame_order) == self._video.shape[0]
+        ), f"The number of frames in the strobe sequence does not match the number of frames in {file_path}."
+        self._num_frames = len(self.frame_indices)
+
+        # check image axis order is height by width
+        self._width, self._height = self._video.shape[1:]
+        self._dtype = self._video.dtype
+
+        # h5py not works with this file (matlab 5.0 file)
+        info_file = read_mat(info_file_path)
+        assert "info" in info_file, f"'info' is not in {file_path}."
+        self._sampling_frequency = float(info_file["info"]["frameRate"]) / 2  # because of blue/violet strobe
+
+    def get_image_size(self) -> Tuple[int, int]:
+        return self._height, self._width
+
+    def get_num_frames(self) -> int:
+        return self._num_frames
+
+    def get_sampling_frequency(self) -> float:
+        return self._sampling_frequency
+
+    def get_channel_names(self) -> List[str]:
+        return [f"OpticalChannel{self.channel_name.capitalize()}"]
+
+    def get_num_channels(self) -> int:
+        return 1
+
+    def get_dtype(self) -> DtypeType:
+        return self._dtype
+
+    def get_video(
+        self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0
+    ) -> np.ndarray:
+        if start_frame is not None and end_frame is not None and start_frame == end_frame:
+            video_start_frame = int(self.frame_indices[start_frame])
+            return self._video[video_start_frame].transpose((1, 0))
+
+        start_frame = start_frame or 0
+        end_frame = end_frame or self.get_num_frames()
+
+        # Ensure the end_frame does not exceed the available frames
+        start_frame = min(start_frame, self.get_num_frames() - 1)
+        end_frame = min(end_frame, self.get_num_frames() - 1)
+
+        original_video_start_frame = self.frame_indices[start_frame]
+        original_video_end_frame = self.frame_indices[end_frame]
+
+        video = (
+            self._video.lazy_slice[original_video_start_frame:original_video_end_frame, ...]
+            .lazy_transpose(axis_order=(0, 2, 1))
+            .dsetread()
+        )
+
+        filtered_indices = self.frame_indices[start_frame:end_frame] - self.frame_indices[start_frame]
+
+        return video[filtered_indices]

--- a/src/pinto_lab_to_nwb/widefield/general_metadata.yaml
+++ b/src/pinto_lab_to_nwb/widefield/general_metadata.yaml
@@ -1,0 +1,10 @@
+NWBFile:
+  session_description:
+    A rich text description of the experiment. Can also just be the abstract of the publication.
+  institution: Northwestern University
+  lab: Pinto
+  experimenter:
+    - Luo, Jiaqi
+Subject:
+  species: Mus musculus
+  sex: U

--- a/src/pinto_lab_to_nwb/widefield/interfaces/__init__.py
+++ b/src/pinto_lab_to_nwb/widefield/interfaces/__init__.py
@@ -1,0 +1,2 @@
+from .widefield_imaginginterface import WidefieldImagingInterface
+from .widefield_processed_imaginginterface import WidefieldProcessedImagingInterface

--- a/src/pinto_lab_to_nwb/widefield/interfaces/widefield_imaginginterface.py
+++ b/src/pinto_lab_to_nwb/widefield/interfaces/widefield_imaginginterface.py
@@ -1,0 +1,71 @@
+from typing import Optional
+
+from dateutil.parser import parse
+from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
+from neuroconv.tools.roiextractors import get_nwb_imaging_metadata
+from neuroconv.utils import FolderPathType, dict_deep_update, FilePathType
+
+from pinto_lab_to_nwb.widefield.extractors.widefield_imagingextractor import WidefieldImagingExtractor
+
+
+class WidefieldImagingInterface(BaseImagingExtractorInterface):
+    """Data Interface for WidefieldImagingExtractor."""
+
+    Extractor = WidefieldImagingExtractor
+
+    def __init__(
+        self,
+        folder_path: FolderPathType,
+        strobe_sequence_file_path: FilePathType,
+        channel_name: Optional[str] = "blue",
+        verbose: bool = True,
+    ):
+        """
+        Data Interface for WidefieldImagingExtractor.
+
+        Parameters
+        ----------
+        folder_path : FolderPathType
+            The folder path that contains the OME-TIF image files (.ome.tif files) and
+           the 'DisplaySettings' JSON file.
+        strobe_sequence_file_path: FilePathType
+            The file path to the strobe sequence file. This file should contain the 'strobe_session_key' key.
+        channel_name: str, optional
+            The name of the channel to load the frames for. The default is 'blue'.
+        verbose : bool, default: True
+        """
+        super().__init__(
+            folder_path=folder_path, strobe_sequence_file_path=strobe_sequence_file_path, channel_name=channel_name
+        )
+        self.channel_name = channel_name
+        self.verbose = verbose
+
+    def get_metadata_schema(self) -> dict:
+        metadata_schema = super().get_metadata_schema(photon_series_type="OnePhotonSeries")
+        return metadata_schema
+
+    def get_metadata(self) -> dict:
+        metadata = super().get_metadata()
+        default_metadata = get_nwb_imaging_metadata(self.imaging_extractor, photon_series_type="OnePhotonSeries")
+        metadata = dict_deep_update(metadata, default_metadata)
+        # Remove default TwoPhotonSeries metadata to only contain metadata for OnePhotonSeries
+        metadata["Ophys"].pop("TwoPhotonSeries", None)
+
+        micromanager_metadata = self.imaging_extractor.micromanager_metadata
+        session_start_time = parse(micromanager_metadata["Summary"]["StartTime"])
+        metadata["NWBFile"].update(session_start_time=session_start_time)
+
+        imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
+        imaging_plane_name = imaging_plane_metadata["name"] + self.channel_name.capitalize()
+        imaging_plane_metadata.update(
+            name=imaging_plane_name,
+            imaging_rate=self.imaging_extractor.get_sampling_frequency(),
+        )
+        one_photon_series_metadata = metadata["Ophys"]["OnePhotonSeries"][0]
+        one_photon_series_name = one_photon_series_metadata["name"] + self.channel_name.capitalize()
+        one_photon_series_metadata.update(
+            name=one_photon_series_name,
+            imaging_plane=imaging_plane_name,
+        )
+
+        return metadata

--- a/src/pinto_lab_to_nwb/widefield/interfaces/widefield_processed_imaginginterface.py
+++ b/src/pinto_lab_to_nwb/widefield/interfaces/widefield_processed_imaginginterface.py
@@ -1,0 +1,73 @@
+from typing import Optional
+
+from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
+from neuroconv.tools.roiextractors import get_nwb_imaging_metadata
+from neuroconv.utils import FilePathType, dict_deep_update
+
+from pinto_lab_to_nwb.widefield.extractors.widefield_processed_imagingextractor import (
+    WidefieldProcessedImagingExtractor,
+)
+
+
+class WidefieldProcessedImagingInterface(BaseImagingExtractorInterface):
+    """Data Interface for ProcessedMiniscopeImagingExtractor."""
+
+    Extractor = WidefieldProcessedImagingExtractor
+
+    def __init__(
+        self,
+        file_path: FilePathType,
+        info_file_path: FilePathType,
+        strobe_sequence_file_path: FilePathType,
+        channel_name: Optional[str] = "blue",
+        verbose: bool = True,
+    ):
+        """
+        Initialize reading the processed Widefield (downsampled by a factor of 8) imaging data.
+
+        Parameters
+        ----------
+        file_path : FilePathType
+            The path that points to downsampled imaging data saved as a Matlab file.
+        info_file_path: FilePathType
+            The path that points to Matlab file with information about the imaging session (e.g. 'frameRate').
+        strobe_sequence_file_path: PathType
+            The path that points to the strobe sequence file. This file should contain the 'strobe_session_key' key.
+        channel_name: str, optional
+            The name of the channel to load the frames for. The default is 'blue'.
+        """
+
+        super().__init__(
+            file_path=file_path,
+            info_file_path=info_file_path,
+            strobe_sequence_file_path=strobe_sequence_file_path,
+            channel_name=channel_name,
+        )
+        self.channel_name = channel_name
+        self.verbose = verbose
+
+    def get_metadata_schema(self) -> dict:
+        metadata_schema = super().get_metadata_schema(photon_series_type="OnePhotonSeries")
+        return metadata_schema
+
+    def get_metadata(self) -> dict:
+        metadata = super().get_metadata()
+
+        default_metadata = get_nwb_imaging_metadata(self.imaging_extractor, photon_series_type="OnePhotonSeries")
+        metadata = dict_deep_update(metadata, default_metadata)
+        # Remove default TwoPhotonSeries metadata to only contain metadata for OnePhotonSeries
+        metadata["Ophys"].pop("TwoPhotonSeries", None)
+
+        imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
+        imaging_plane_metadata.update(
+            name=f"ImagingPlane{self.channel_name.capitalize()}",
+            imaging_rate=self.imaging_extractor.get_sampling_frequency(),
+        )
+        metadata["Ophys"]["OnePhotonSeries"][0].update(
+            name=f"OnePhotonSeriesProcessed{self.channel_name.capitalize()}",
+            description="Processed imaging data from one-photon excitation microscopy.",
+            imaging_plane=imaging_plane_metadata["name"],
+            binning=64,  # downsampled by a factor of 8 (x,y)
+        )
+
+        return metadata

--- a/src/pinto_lab_to_nwb/widefield/widefield_convert_session.py
+++ b/src/pinto_lab_to_nwb/widefield/widefield_convert_session.py
@@ -1,0 +1,81 @@
+"""Primary script to run to convert an entire session for of data using the NWBConverter."""
+import re
+from pathlib import Path
+from dateutil import tz
+from neuroconv.utils import (
+    load_dict_from_file,
+    dict_deep_update,
+    FolderPathType,
+    FilePathType,
+)
+
+from pinto_lab_to_nwb.widefield import WideFieldNWBConverter
+
+
+def session_to_nwb(
+    nwbfile_path: FilePathType,
+    widefield_imaging_folder_path: FolderPathType,
+    stub_test: bool = False,
+):
+    """
+    Converts a single session to NWB.
+
+    Parameters
+    ----------
+    nwbfile_path : FilePathType
+        The file path to the NWB file that will be created.
+    widefield_imaging_folder_path: FolderPathType
+        The folder path that contains the Micro-Manager OME-TIF imaging output (.ome.tif files).
+    stub_test: bool, optional
+        For testing purposes, when stub_test=True only writes a subset of imaging and segmentation data.
+    """
+    widefield_imaging_folder_path = Path(widefield_imaging_folder_path)
+
+    source_data = dict()
+    conversion_options = dict()
+
+    # Add Imaging
+    imaging_source_data = dict(folder_path=str(widefield_imaging_folder_path))
+    source_data.update(dict(Imaging=imaging_source_data))
+    conversion_options.update(dict(Imaging=dict(stub_test=stub_test)))
+
+    converter = WideFieldNWBConverter(source_data=source_data)
+
+    # Add datetime to conversion
+    metadata = converter.get_metadata()
+    # For data provenance we can add the time zone information to the conversion if missing
+    session_start_time = metadata["NWBFile"]["session_start_time"]
+    tzinfo = tz.gettz("US/Pacific")
+    metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
+
+    # Update default metadata with the editable in the corresponding yaml file
+    editable_metadata_path = Path(__file__).parent / "general_metadata.yaml"
+    editable_metadata = load_dict_from_file(editable_metadata_path)
+    metadata = dict_deep_update(metadata, editable_metadata)
+
+    # Update metadata with subject_id and session_id from folder_path
+    # TS12_20220407_20hz_noteasy_1
+    file_naming_pattern = r"^(?P<subject_id>[^_]+)_(?P<session_id>.+)"
+    match = re.match(file_naming_pattern, str(widefield_imaging_folder_path.name))
+    if match:
+        groups_dict = match.groupdict()
+        metadata["NWBFile"].update(session_id=groups_dict["session_id"].replace("_", "-"))
+        metadata["Subject"].update(subject_id=groups_dict["subject_id"])
+
+    # Run conversion
+    converter.run_conversion(
+        nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True, conversion_options=conversion_options
+    )
+
+
+if __name__ == "__main__":
+    # Parameters for conversion
+    imaging_folder_path = Path("/Volumes/t7-ssd/Pinto/TS12_20220407_20hz_noteasy_1")
+    nwbfile_path = Path("/Volumes/t7-ssd/Pinto/nwbfiles/widefield/TS12_20220407_20hz_noteasy_1.nwb")
+    stub_test = False
+
+    session_to_nwb(
+        nwbfile_path=nwbfile_path,
+        widefield_imaging_folder_path=imaging_folder_path,
+        stub_test=stub_test,
+    )

--- a/src/pinto_lab_to_nwb/widefield/widefield_requirements.txt
+++ b/src/pinto_lab_to_nwb/widefield/widefield_requirements.txt
@@ -1,0 +1,1 @@
+neuroconv[micromanagertiff]

--- a/src/pinto_lab_to_nwb/widefield/widefieldnwbconverter.py
+++ b/src/pinto_lab_to_nwb/widefield/widefieldnwbconverter.py
@@ -1,11 +1,15 @@
 """Primary NWBConverter class for this dataset."""
 from neuroconv import NWBConverter
-from neuroconv.datainterfaces import MicroManagerTiffImagingInterface
+
+from pinto_lab_to_nwb.widefield.interfaces import WidefieldImagingInterface, WidefieldProcessedImagingInterface
 
 
 class WideFieldNWBConverter(NWBConverter):
     """Primary conversion class for Widefield imaging dataset."""
 
     data_interface_classes = dict(
-        Imaging=MicroManagerTiffImagingInterface,
+        ImagingBlue=WidefieldImagingInterface,
+        ImagingViolet=WidefieldImagingInterface,
+        ProcessedImagingBlue=WidefieldProcessedImagingInterface,
+        ProcessedImagingViolet=WidefieldProcessedImagingInterface,
     )

--- a/src/pinto_lab_to_nwb/widefield/widefieldnwbconverter.py
+++ b/src/pinto_lab_to_nwb/widefield/widefieldnwbconverter.py
@@ -1,0 +1,11 @@
+"""Primary NWBConverter class for this dataset."""
+from neuroconv import NWBConverter
+from neuroconv.datainterfaces import MicroManagerTiffImagingInterface
+
+
+class WideFieldNWBConverter(NWBConverter):
+    """Primary conversion class for Widefield imaging dataset."""
+
+    data_interface_classes = dict(
+        Imaging=MicroManagerTiffImagingInterface,
+    )


### PR DESCRIPTION
The Widefield imaging data consists of:

Raw Imaging
- Micro-Manager ome-tif format (image size: 1024, 1024)
- Has blue and violet frames 

Downsampled Imaging
- .mat file (image size: 128, 128)
- Has blue and violet frames

Strobe sequence
- strobe sequence data (values are 1 or 2): tells us the order of blue and violet frames
- 1 corresponds to blue frame
- 2 corresponds to violet frame

Since for segmentation they only consider the blue frames, we are saving `OnePhotonSeries` data for each channel.
The extractors should read the raw and processed data, and based on the strobe sequence they should subset the frames depending on which channel they are loading.

