### PR TITLE
Add subject metadata

### DIFF
--- a/src/pinto_lab_to_nwb/general/__init__.py
+++ b/src/pinto_lab_to_nwb/general/__init__.py
@@ -1,0 +1,1 @@
+from .subject import make_subject_metadata

--- a/src/pinto_lab_to_nwb/general/subject.py
+++ b/src/pinto_lab_to_nwb/general/subject.py
@@ -12,12 +12,14 @@ def make_subject_metadata(subject_id: str, subject_metadata_file_path: str) -> d
     subject_metadata = subject_mat["metadata"]
 
     if subject_id not in subject_metadata["subject_nickname"]:
-        warn(f"Subject '{subject_id}' not found in subject metadata file '{subject_metadata_file_path}'."
-             f"The metadata for this subject will not be added to the NWB file.")
+        warn(
+            f"Subject '{subject_id}' not found in subject metadata file '{subject_metadata_file_path}'."
+            f"The metadata for this subject will not be added to the NWB file."
+        )
         return dict()
 
     subject_ind = subject_metadata["subject_nickname"].index(subject_id)
-    date_of_birth = datetime.strptime(subject_metadata["dob"][subject_ind], '%Y-%m-%d')
+    date_of_birth = datetime.strptime(subject_metadata["dob"][subject_ind], "%Y-%m-%d")
     tzinfo = tz.gettz("US/Pacific")
     date_of_birth = date_of_birth.replace(tzinfo=tzinfo)
 

--- a/src/pinto_lab_to_nwb/general/subject.py
+++ b/src/pinto_lab_to_nwb/general/subject.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from warnings import warn
+
+from dateutil import tz
+from pymatreader import read_mat
+
+
+def make_subject_metadata(subject_id: str, subject_metadata_file_path: str) -> dict:
+    subject_mat = read_mat(subject_metadata_file_path)
+
+    assert "metadata" in subject_mat, f"The subject file '{subject_metadata_file_path}' should have a 'metadata' key."
+    subject_metadata = subject_mat["metadata"]
+
+    if subject_id not in subject_metadata["subject_nickname"]:
+        warn(f"Subject '{subject_id}' not found in subject metadata file '{subject_metadata_file_path}'."
+             f"The metadata for this subject will not be added to the NWB file.")
+        return dict()
+
+    subject_ind = subject_metadata["subject_nickname"].index(subject_id)
+    date_of_birth = datetime.strptime(subject_metadata["dob"][subject_ind], '%Y-%m-%d')
+    tzinfo = tz.gettz("US/Pacific")
+    date_of_birth = date_of_birth.replace(tzinfo=tzinfo)
+
+    sex_mapping = dict(Male="M", Female="F")
+    subject_kwargs = dict(
+        date_of_birth=date_of_birth,
+        subject_id=subject_id,
+        sex=sex_mapping[subject_metadata["sex"][subject_ind]],
+        genotype=subject_metadata["line"][subject_ind],
+        species="Mus musculus",
+    )
+    subject_description = subject_metadata["subject_description"][subject_ind]
+    if subject_description:
+        subject_kwargs["description"] = subject_description
+
+    metadata = dict(Subject=subject_kwargs, NWBFile=dict(protocol=subject_metadata["protocol"][subject_ind]))
+    return metadata

--- a/src/pinto_lab_to_nwb/general/subject.py
+++ b/src/pinto_lab_to_nwb/general/subject.py
@@ -22,12 +22,12 @@ def make_subject_metadata(subject_id: str, subject_metadata_file_path: str) -> d
     date_of_birth = date_of_birth.replace(tzinfo=tzinfo)
 
     sex_mapping = dict(Male="M", Female="F")
+    # TODO: ear_tag_id, and zygosity are in the metadata file, but would require an extension of Subject to add, should it be added?
     subject_kwargs = dict(
         date_of_birth=date_of_birth,
         subject_id=subject_id,
         sex=sex_mapping[subject_metadata["sex"][subject_ind]],
         genotype=subject_metadata["line"][subject_ind],
-        species="Mus musculus",
     )
     subject_description = subject_metadata["subject_description"][subject_ind]
     if subject_description:

--- a/src/pinto_lab_to_nwb/widefield/widefield_convert_session.py
+++ b/src/pinto_lab_to_nwb/widefield/widefield_convert_session.py
@@ -126,7 +126,9 @@ def session_to_nwb(
         metadata["Subject"].update(subject_id=groups_dict["subject_id"])
 
         if subject_metadata_file_path:
-            subject_metadata = make_subject_metadata(subject_id=groups_dict["subject_id"], subject_metadata_file_path=subject_metadata_file_path)
+            subject_metadata = make_subject_metadata(
+                subject_id=groups_dict["subject_id"], subject_metadata_file_path=subject_metadata_file_path
+            )
             metadata = dict_deep_update(metadata, subject_metadata)
 
     # Run conversion


### PR DESCRIPTION
Add utility method to create a dict that contains the subject metadata loaded from the provided "subject_metadata.mat" file.
- "subject_metadata.mat" contains the metadata for multiple subjects, see:
<img width="1119" alt="Screenshot 2023-11-18 at 22 15 31" src="https://github.com/catalystneuro/pinto-lab-to-nwb/assets/24475788/9341e12d-4d57-4ca0-8f78-6250b6a0ae17">

TODO:
- [ ] not sure whether to add `ear_tag_id` and `zygosity`: they would require an extension for subject which is easy to do, but should ask Renan or Lucas whether they need it 


The snapshot of an example NWBFile:
<img width="1014" alt="Screenshot 2023-11-18 at 22 13 19" src="https://github.com/catalystneuro/pinto-lab-to-nwb/assets/24475788/953e6599-abe0-47a8-9ec4-a4482b6422e7">
