### PR TITLE
Fix Widefield segmentation file names change

### DIFF
--- a/src/pinto_lab_to_nwb/widefield/interfaces/widefield_processed_segmentationinterface.py
+++ b/src/pinto_lab_to_nwb/widefield/interfaces/widefield_processed_segmentationinterface.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from neuroconv.datainterfaces.ophys.basesegmentationextractorinterface import BaseSegmentationExtractorInterface
 from neuroconv.tools import get_module
-from neuroconv.utils import FolderPathType
+from neuroconv.utils import FilePathType
 from pynwb import NWBFile
 
 from pinto_lab_to_nwb.widefield.extractors.widefield_processed_segmentationextractor import (
@@ -15,15 +15,33 @@ class WidefieldProcessedSegmentationinterface(BaseSegmentationExtractorInterface
 
     Extractor = WidefieldProcessedSegmentationExtractor
 
-    def __init__(self, folder_path: FolderPathType, verbose: bool = True):
+    def __init__(
+            self,
+            info_mat_file_path: FilePathType,
+            roi_from_ref_mat_file_path: FilePathType,
+            vasculature_mask_file_path: FilePathType,
+            blue_pca_mask_file_path: FilePathType,
+            verbose: bool = True):
         """
 
         Parameters
         ----------
-        folder_path : FolderPathType
+        info_mat_file_path : FilePathType
+            The file path to the 'info.mat' file.
+        roi_from_ref_mat_file_path : FilePathType
+            The file that contains the Allen area label of each pixel mapped onto the reference image of the mouse and registered to the session.
+        vasculature_mask_file_path: FilePathType
+            The file that contains the vasculature mask on the downsampled (binned) session image.
+        blue_pca_mask_file_path: FilePathType
+            The file that contains the PCA mask for the blue channel.
         verbose : bool, default: True
         """
-        super().__init__(folder_path=folder_path)
+        super().__init__(
+            info_mat_file_path=info_mat_file_path,
+            roi_from_ref_mat_file_path=roi_from_ref_mat_file_path,
+            vasculature_mask_file_path=vasculature_mask_file_path,
+            blue_pca_mask_file_path=blue_pca_mask_file_path,
+        )
         self.verbose = verbose
 
     def get_metadata(self) -> dict:

--- a/src/pinto_lab_to_nwb/widefield/interfaces/widefield_segmentation_images_violet_datainterface.py
+++ b/src/pinto_lab_to_nwb/widefield/interfaces/widefield_segmentation_images_violet_datainterface.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import numpy as np
 from neuroconv import BaseDataInterface
 from neuroconv.tools import get_module
-from neuroconv.utils import FolderPathType
+from neuroconv.utils import FilePathType
 from pymatreader import read_mat
 from pynwb import NWBFile
 from pynwb.base import Images
@@ -13,28 +13,26 @@ from pynwb.image import GrayscaleImage
 class WidefieldSegmentationImagesVioletInterface(BaseDataInterface):
     """The custom interface to add the violet channel PCA mask to the NWBFile."""
 
-    def __init__(self, folder_path: FolderPathType, verbose: bool = True):
+    def __init__(self, violet_pca_mask_file_path: FilePathType, verbose: bool = True):
         """
         The interface to add the summary images to the NWBFile.
 
         Parameters
         ----------
-        folder_path : FolderPathType
+        violet_pca_mask_file_path : FilePathType
+            The file path to the violet channel PCA mask file.
         verbose : bool, default: True
         """
-        super().__init__(folder_path=folder_path)
-        self.folder_path = Path(folder_path)
+        super().__init__(violet_pca_mask_file_path=violet_pca_mask_file_path)
+        self.violet_pca_mask_file_path = Path(violet_pca_mask_file_path)
+        assert self.violet_pca_mask_file_path.exists(), f"The violet channel PCA mask file '{violet_pca_mask_file_path}' does not exist."
         self.verbose = verbose
 
         self._image_pca_violet = self._load_pca_mask()
 
     def _load_pca_mask(self) -> np.ndarray:
-        pca_mask_file_path = self.folder_path / "violet_pca_vasculature_mask_2.mat"
-        assert (
-            pca_mask_file_path.exists()
-        ), f"The PCA mask file for the violet channel is missing from {self.folder_path}."
-        pca_mask_violet = read_mat(str(pca_mask_file_path))
-        assert "vasc_mask" in pca_mask_violet, f"Could not find 'vasc_mask' in 'violet_pca_vasculature_mask_2.mat'."
+        pca_mask_violet = read_mat(str(self.violet_pca_mask_file_path))
+        assert "vasc_mask" in pca_mask_violet, f"Could not find 'vasc_mask' in '{self.violet_pca_mask_file_path}'."
         pca_mask = pca_mask_violet["vasc_mask"]
 
         return pca_mask

--- a/src/pinto_lab_to_nwb/widefield/widefield_convert_session.py
+++ b/src/pinto_lab_to_nwb/widefield/widefield_convert_session.py
@@ -21,6 +21,13 @@ def session_to_nwb(
     strobe_sequence_file_path: FilePathType,
     processed_imaging_file_path: FilePathType,
     info_file_path: FilePathType,
+    vasculature_mask_file_path: FilePathType,
+    manual_mask_file_path: FilePathType,
+    manual_mask_struct_name: str,
+    roi_from_ref_mat_file_path: FilePathType,
+    binned_vasculature_mask_file_path: FilePathType,
+    binned_blue_pca_mask_file_path: FilePathType,
+    binned_violet_pca_mask_file_path: FilePathType,
     subject_metadata_file_path: Optional[FilePathType] = None,
     stub_test: bool = False,
 ):
@@ -37,6 +44,20 @@ def session_to_nwb(
             The file path to the strobe sequence file. This file should contain the 'strobe_session_key' key.
     info_file_path: FilePathType
         The file path to the Matlab file with information about the imaging session (e.g. 'frameRate').
+    vasculature_mask_file_path: FilePathType
+        The file path that contains the contrast based vasculature mask on the full size session image (blue channel).
+    manual_mask_file_path: FilePathType
+        The file path that contains the manual mask on the full size session image (blue channel).
+    manual_mask_struct_name: str
+        The name of the struct in the manual mask file that contains the manual mask (e.g. "regMask" or "reg_manual_mask").
+    roi_from_ref_mat_file_path: FilePathType
+        The file path that contains the Allen area label of each pixel mapped onto the reference image of the mouse and registered to the session.
+    binned_vasculature_mask_file_path: FilePathType
+        The file path that contains the contrast based vasculature mask on the downsampled (binned) session image (blue channel).
+    binned_blue_pca_mask_file_path: FilePathType
+        The file path that contains the PCA mask for the blue channel.
+    binned_violet_pca_mask_file_path: FilePathType
+        The file path that contains the PCA mask for the violet channel.
     subject_metadata_file_path: FilePathType, optional
         The file path to the subject metadata file. This file should contain the 'metadata' key.
     stub_test: bool, optional
@@ -106,13 +127,18 @@ def session_to_nwb(
     source_data.update(
         dict(
             SegmentationProcessedBlue=dict(
-                folder_path=str(widefield_imaging_folder_path),
+                info_mat_file_path=str(info_file_path),
+                roi_from_ref_mat_file_path=str(roi_from_ref_mat_file_path),
+                vasculature_mask_file_path=str(binned_vasculature_mask_file_path),
+                blue_pca_mask_file_path=str(binned_blue_pca_mask_file_path),
             ),
             SummaryImagesBlue=dict(
-                folder_path=str(widefield_imaging_folder_path),
+                vasculature_mask_file_path=str(vasculature_mask_file_path),
+                manual_mask_file_path=str(manual_mask_file_path),
+                manual_mask_struct_name=manual_mask_struct_name,
             ),
             SummaryImagesViolet=dict(
-                folder_path=str(widefield_imaging_folder_path),
+                violet_pca_mask_file_path=str(binned_violet_pca_mask_file_path),
             ),
         )
     )
@@ -156,13 +182,39 @@ if __name__ == "__main__":
     # Parameters for conversion
 
     # The folder path that contains the raw imaging data in Micro-Manager OME-TIF format (.ome.tif files).
-    imaging_folder_path = Path("/Users/weian/data/DrChicken_20230419_20hz")
+    #imaging_folder_path = Path("/Users/weian/data/Cherry/20230802/Cherry_20230802_20hz_1")
+    imaging_folder_path = Path("/Volumes/t7-ssd/Pinto/DrChicken_20230419_20hz")
     # The file path to the strobe sequence file.
     strobe_sequence_file_path = imaging_folder_path / "strobe_seq_1_2.mat"
     # The file path to the downsampled imaging data in Matlab format (.mat file).
     processed_imaging_path = imaging_folder_path / "rawf_full.mat"
     # The file path to the Matlab file with information about the imaging session (e.g. 'frameRate').
     info_file_path = imaging_folder_path / "info.mat"
+
+    # Parameters for custom segmentation and summary images
+    # The file path that contains the contrast based vasculature mask on the full size session image (blue channel).
+    vasculature_mask_file_path = imaging_folder_path / "vasculature_mask_2.mat"
+
+    # The file path that contains the manual mask on the full size session image (blue channel).
+    #manual_mask_file_path = imaging_folder_path / "reg_manual_mask_jlt6316_Cherry_20230802_1_1_1.mat"
+    manual_mask_file_path = imaging_folder_path / "regManualMask.mat"
+    # The name of the struct in the manual mask file that contains the manual mask (e.g. "regMask" or "reg_manual_mask").
+    #manual_mask_struct_name = "reg_manual_mask"
+    manual_mask_struct_name = "regMask"
+
+    # The file path that contains the Allen area label of each pixel mapped onto the reference image of the mouse and registered to the session.
+    #roi_from_ref_mat_file_path = imaging_folder_path / "ROIfromRef_1.mat"
+    roi_from_ref_mat_file_path = imaging_folder_path / "ROIfromRef.mat"
+
+    # The file path that contains the contrast based vasculature mask on the downsampled (binned) session image (blue channel).
+    binned_vasculature_mask_file_path = imaging_folder_path / "vasculature_mask_2.mat"
+
+    # The file path that contains the PCA mask for the blue channel.
+    binned_blue_pca_mask_file_path = imaging_folder_path / "blue_pca_vasculature_mask_2.mat"
+
+    # The file path that contains the PCA mask for the violet channel.
+    binned_violet_pca_mask_file_path = imaging_folder_path / "violet_pca_vasculature_mask_2.mat"
+
     subject_metadata_file_path = "/Volumes/t7-ssd/Pinto/Behavior/subject_metadata.mat"
     # The file path to the NWB file that will be created.
     nwbfile_path = Path("/Volumes/t7-ssd/Pinto/nwbfiles/widefield/DrChicken_20230419_20hz.nwb")
@@ -175,6 +227,13 @@ if __name__ == "__main__":
         strobe_sequence_file_path=strobe_sequence_file_path,
         processed_imaging_file_path=processed_imaging_path,
         info_file_path=info_file_path,
+        vasculature_mask_file_path=vasculature_mask_file_path,
+        manual_mask_file_path=manual_mask_file_path,
+        manual_mask_struct_name=manual_mask_struct_name,
+        roi_from_ref_mat_file_path=roi_from_ref_mat_file_path,
+        binned_vasculature_mask_file_path=binned_vasculature_mask_file_path,
+        binned_blue_pca_mask_file_path=binned_blue_pca_mask_file_path,
+        binned_violet_pca_mask_file_path=binned_violet_pca_mask_file_path,
         subject_metadata_file_path=subject_metadata_file_path,
         stub_test=stub_test,
     )

--- a/src/pinto_lab_to_nwb/widefield/widefield_convert_session.py
+++ b/src/pinto_lab_to_nwb/widefield/widefield_convert_session.py
@@ -41,7 +41,7 @@ def session_to_nwb(
     widefield_imaging_folder_path: FolderPathType
         The folder path that contains the Micro-Manager OME-TIF imaging output (.ome.tif files).
     strobe_sequence_file_path: FilePathType
-            The file path to the strobe sequence file. This file should contain the 'strobe_session_key' key.
+        The file path to the strobe sequence file. This file should contain the 'strobe_session_key' key.
     info_file_path: FilePathType
         The file path to the Matlab file with information about the imaging session (e.g. 'frameRate').
     vasculature_mask_file_path: FilePathType

--- a/src/pinto_lab_to_nwb/widefield/widefield_notes.md
+++ b/src/pinto_lab_to_nwb/widefield/widefield_notes.md
@@ -1,0 +1,52 @@
+# Notes concerning the `widefield` conversion
+
+## Imaging folder structure
+
+See the example folder structure [here](https://gin.g-node.org/CatalystNeuro/ophys_testing_data/src/main/imaging_datasets/MicroManagerTif) for the MicroManager OME-TIF format.
+
+## Segmentation files structure
+
+Required files for custom segmentation and summary images:
+
+Summary images for the full size session image (blue channel):
+- `"vasculature_mask_file_path"`: The file path that contains the contrast based vasculature mask on the full size session image (blue channel).
+- `"manual_mask_file_path`: The file path that contains the manual mask on the full size session image (blue channel).
+Summary images for the binned session image (blue channel, violet channel):
+- `"binned_vasculature_mask_file_path"`: The file path that contains the contrast based vasculature mask on the downsampled (binned) session image (blue channel).
+- `"binned_blue_pca_mask_file_path"`: The file path that contains the PCA mask for the blue channel.
+- `"binned_violet_pca_mask_file_path"`: The file path that contains the PCA mask for the violet channel.
+ROI masks and Allen area labels for the binned session image (blue channel):
+- `"roi_from_ref_mat_file_path"`: The file path that contains the Allen area label of each pixel mapped onto the reference image of the mouse and registered to the session.
+- `"info_file_path"`: The file path that contains the information about the imaging session (e.g. number of frames, frame rate, etc.).
+
+## Run conversion for a single session
+
+`widefield_convert_sesion.py`: this script defines the function to convert one full session of the conversion.
+Parameters:
+- "`widefield_imaging_folder_path`" : The folder path that contains the Micro-Manager OME-TIF imaging output (.ome.tif files).
+- "`strobe_sequence_file_path`": The file path to the strobe sequence file. This file should contain the 'strobe_session_key' key.
+- "`info_file_path`": The file path to the Matlab file with information about the imaging session (e.g. 'frameRate').
+- "`vasculature_mask_file_path`": The file path that contains the contrast based vasculature mask on the full size session image (blue channel).
+- "`manual_mask_file_path`": The file path that contains the manual mask on the full size session image (blue channel).
+- "`manual_mask_struct_name`": The name of the struct in the manual mask file that contains the manual mask (e.g. "regMask" or "reg_manual_mask").
+- "`roi_from_ref_mat_file_path`": The file path that contains the Allen area label of each pixel mapped onto the reference image of the mouse and registered to the session.
+- "`binned_vasculature_mask_file_path`": The file path that contains the contrast based vasculature mask on the downsampled (binned) session image (blue channel).
+- "`binned_blue_pca_mask_file_path`": The file path that contains the PCA mask for the blue channel.
+- "`binned_violet_pca_mask_file_path`": The file path that contains the PCA mask for the violet channel.
+- "`subject_metadata_file_path`": The file path that contains the subject metadata (e.g. subject_id, genotype, etc.).
+
+### Example usage
+
+To run a specific conversion, you might need to install first some conversion specific dependencies that are located in each conversion directory:
+```
+cd src/pinto_lab_to_nwb/widefield
+pip install -r widefield_requirements.txt
+```
+Then you can run a specific conversion with the following command:
+```
+python widefield_convert_session.py
+```
+
+### Tutorials
+
+See the [widefield tutorial](./tutorials/widefield_demo.ipynb) that demonstrates how to read and access the data in NWB.


### PR DESCRIPTION
The recently shared Widefield session ("Cherry_20230802_20hz_1") showed that the name of the segmentation files can change (even the name of an expected struct name) so this PR modifies the segmentation extractors and interfaces to take the file paths directly. 

Added a note that provides a description for each parameter in the current `widefield_convert_session.py` script.
